### PR TITLE
doc(README.md): Add link to blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,6 @@ Markdown format is commonplace on the Internet: in forums, blogs, source code re
 
 Markdown files usually end with the .md extension and follow the Markdown text format.
 
+### Where can I read more about the process of building this script?
+
+On my blog here: https://davidalfonso.es/posts/migrating-from-tiddlywiki-to-markdown-files


### PR DESCRIPTION
While researching an export I came across the blog post and the repo separately, would be useful to link from one to the other imo.

Either way thank you for sharing this online :)