### PR TITLE
Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 *.json
 *.html
 
+!package.json
+
+node_modules/
+markdown_tiddlers/
+tmp_wiki/

--- a/Makefile
+++ b/Makefile
@@ -30,12 +30,12 @@ MARKDOWN_TIDDLERS := $(patsubst $(TW_OUTPUT_DIR)/%.html, \
 .PHONY: export-html
 export-html : deps pre
 	@echo "Exporting all tiddlers from $(ORIGINAL_TIDDLYWIKI) to html"
-	$(NODEJS) $(TIDDLYWIKI_JS) $(WIKI_NAME) --load $(ORIGINAL_TIDDLYWIKI) \
+	"$(NODEJS)" $(TIDDLYWIKI_JS) $(WIKI_NAME) --load $(ORIGINAL_TIDDLYWIKI) \
         --render [!is[system]] [encodeuricomponent[]addsuffix[.html]] \
         --render [!is[system]] [encodeuricomponent[]addsuffix[.meta]] \
             text/plain $$:/core/templates/tiddler-metadata
 	@echo "Renaming all .html and .meta files to safe characters..."
-	$(NODEJS) $(SAFE_RENAME_JS) $(TW_OUTPUT_DIR)
+	"$(NODEJS)" $(SAFE_RENAME_JS) $(TW_OUTPUT_DIR)
 
 .PHONY: deps
 deps :
@@ -64,13 +64,13 @@ $(ORIGINAL_TIDDLYWIKI) :
 
 $(TIDDLYWIKI_JS) :
 	@echo "Installing TiddlyWiki..."
-	$(NPM) install tiddlywiki
+	"$(NPM)" install tiddlywiki
  
 $(TIDDLYWIKI_INFO) : $(TIDDLYWIKI_JS)
 	@echo "Setting up temporary wiki..."
-	$(NODEJS) $(TIDDLYWIKI_JS) $(WIKI_NAME) --init empty
-	$(NODEJS) $(ADD_PLUGIN_JS) $(TIDDLYWIKI_INFO) tiddlywiki/tw2parser
-	$(NODEJS) $(ADD_PLUGIN_JS) $(TIDDLYWIKI_INFO) tiddlywiki/markdown
+	"$(NODEJS)" $(TIDDLYWIKI_JS) $(WIKI_NAME) --init empty
+	"$(NODEJS)" $(ADD_PLUGIN_JS) $(TIDDLYWIKI_INFO) tiddlywiki/tw2parser
+	"$(NODEJS)" $(ADD_PLUGIN_JS) $(TIDDLYWIKI_INFO) tiddlywiki/markdown
 
 .PHONY: convert
 convert : $(MARKDOWN_DIR) $(MARKDOWN_TIDDLERS)

--- a/README.md
+++ b/README.md
@@ -13,13 +13,17 @@ TiddlyWiki Migrator is a set of scripts put together to automate the migration f
 ## Usage
 
 1. Clone this repository.
-2. Copy your single-file html TiddlyWiki (2 or 5) in your cloned repository.
-3. Rename your TW html to `wiki.html`
-4. Export your tiddlers:
+2. Run `npm install` to install tiddlywiki dependency.
+3. Copy your single-file html TiddlyWiki (2 or 5) in your cloned repository.
+4. Rename your TW html to `wiki.html`
+5. Export your tiddlers:
+
 ```
 $ make
 ```
-5. Convert all your tiddlers to Markdown:
+
+6. Convert all your tiddlers to Markdown:
+
 ```
 $ make convert
 ```
@@ -73,3 +77,13 @@ Markdown files usually end with the .md extension and follow the Markdown text f
 ### Where can I read more about the process of building this script?
 
 I wrote [a post](https://davidalfonso.es/posts/tiddlywiki-to-markdown) with some more detail.
+
+### Windows users
+
+Use [Chocolatey](https://chocolatey.org/install) to provide the underlying dependencies:
+
+Make `choco install make` 
+
+Pandoc `choco install pandoc --ia=ALLUSERS=1`
+
+Many other options available at [Pandoc](https://pandoc.org/installing.html#windows)

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "version": "1.0.0",
   "description": "Export tiddlers from a single-file html TiddlyWiki, \"classic\" or \"modern\", to Markdown.",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "export": "make",
+    "convert": "make && make convert",
+    "clean": "make clean"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/davidag/tiddlywiki-migrator.git"
+    "url": "https://github.com/davidag/tiddlywiki-migrator.git"
   },
   "keywords": [
     "tiddlywiki",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "tiddlywiki-migrator",
+  "version": "1.0.0",
+  "description": "Export tiddlers from a single-file html TiddlyWiki, \"classic\" or \"modern\", to Markdown.",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/davidag/tiddlywiki-migrator.git"
+  },
+  "keywords": [
+    "tiddlywiki",
+    "export",
+    "markdown"
+  ],
+  "author": "David Alfonso",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/davidag/tiddlywiki-migrator/issues"
+  },
+  "homepage": "https://github.com/davidag/tiddlywiki-migrator#readme",
+  "dependencies": {
+    "tiddlywiki": "^5.3.3"
+  }
+}


### PR DESCRIPTION
Small fixes required to reduce friction on Windows 

- Makefile tweak required to fix inevitable problematic "Program Files" path on Windows specifically but should continue to work on other platforms (and handle spaces in folder/directory names)
- package.json included to allow `npm install` of assumed tiddlywiki dependency
- Minor documentation updates to suit

This PR addresses both https://github.com/davidag/tiddlywiki-migrator/issues/3 and https://github.com/davidag/tiddlywiki-migrator/issues/2 by providing the fixes @davidag suggests.

